### PR TITLE
Fix floating point round error

### DIFF
--- a/include/cadmium/celldevs/grid/scenario.hpp
+++ b/include/cadmium/celldevs/grid/scenario.hpp
@@ -201,7 +201,7 @@ namespace cadmium::celldevs {
 				throw CadmiumModelException("p must be greater than 0");
 			}
 			auto x = std::accumulate(distance.begin(), distance.end(), 0., [p](double sum, int v) { return sum + std::pow(std::abs(v), p); });
-			return std::pow(x, 1 / p);
+			return std::pow(x, 1.0 / p);
 		}
 
 		/**


### PR DESCRIPTION
Distance calculations were always returning 1 on MSVC without the changes